### PR TITLE
Add sequence and Streamlit diagrams

### DIFF
--- a/UML/sequence.puml
+++ b/UML/sequence.puml
@@ -1,0 +1,18 @@
+@startuml CommunicationSequence
+actor User
+participant Streamlit
+participant "MQTT Broker" as Broker
+participant ESP32
+participant Sensors
+participant Actuators
+
+User -> Streamlit : interacts via GUI
+Streamlit -> Broker : publish control commands
+Broker -> ESP32 : MQTT message
+ESP32 -> Actuators : set state
+ESP32 -> Sensors : read data
+Sensors --> ESP32 : measurements
+ESP32 -> Broker : publish sensor data
+Broker -> Streamlit : deliver readings
+Streamlit -> User : update interface
+@enduml

--- a/UML/streamlit.puml
+++ b/UML/streamlit.puml
@@ -1,0 +1,13 @@
+@startuml StreamlitFlow
+start
+:Initialize MQTT client;
+:Configure Streamlit page;
+repeat
+  :Receive sensor updates;
+  :Update charts and controls;
+  if (User triggers command?) then (yes)
+    :Publish MQTT command;
+  endif
+repeat while (application running)
+stop
+@enduml


### PR DESCRIPTION
## Summary
- add a PlantUML sequence diagram depicting the full message flow
- add a PlantUML activity diagram describing the Streamlit dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68416e8f8580832784b8c25f2500e83d